### PR TITLE
Add user config capability

### DIFF
--- a/instantdata.sh
+++ b/instantdata.sh
@@ -14,6 +14,10 @@ dotconfigsub(){
 }
 
 
+# ppenguin:
+# better to use "real" getopt (and get rid of the Q&D pattern match below), 
+# but this would break non-standard "half-short" options (-wa -wi -wm) for now,
+# so these should be replaced everywhere where they are called
 for i in "$@"
 do
 case $i in
@@ -26,8 +30,9 @@ case $i in
     --get-dotfiles-dir|-d)
 	echo "@instantDotfiles@"
     ;;
-    --get-userconfig-dir|-uc)
-	dotconfigsub()
+    --get-userconfig-dir=*|-uc=*)
+    optarg=$(echo $* | awk -F' ' '$1~/--get-userconfig-dir|-uc/ { match($1, /.*=(.*)/, a); print a[1] }' )
+	dotconfigsub ${optarg}
     ;;
     --get-logo-dir|-l)
 	echo "@instantLOGO@"

--- a/instantdata.sh
+++ b/instantdata.sh
@@ -1,6 +1,19 @@
 #!/bin/sh
 
 #!/bin/bash
+
+# get a subdir under ~/.config if it exists
+# to override specific config dirs under instantdotfiles
+# (this is necessary e.g. to customise rofi themes as a user)
+dotconfigsub(){
+    if [ -d "${1}" ]; then
+        echo "~/.config/${1}"
+    else
+        echo "@instantDotfiles@/${1}"
+    fi
+}
+
+
 for i in "$@"
 do
 case $i in
@@ -12,6 +25,9 @@ case $i in
     ;;
     --get-dotfiles-dir|-d)
 	echo "@instantDotfiles@"
+    ;;
+    --get-userconfig-dir|-uc)
+	dotconfigsub()
     ;;
     --get-logo-dir|-l)
 	echo "@instantLOGO@"

--- a/instantdata.sh
+++ b/instantdata.sh
@@ -6,7 +6,7 @@
 # to override specific config dirs under instantdotfiles
 # (this is necessary e.g. to customise rofi themes as a user)
 dotconfigsub(){
-    if [ -d "${1}" ]; then
+    if [ -d "~/.config/${1}" ]; then
         echo "~/.config/${1}"
     else
         echo "@instantDotfiles@/${1}"

--- a/instantdata.sh
+++ b/instantdata.sh
@@ -6,10 +6,10 @@
 # to override specific config dirs under instantdotfiles
 # (this is necessary e.g. to customise rofi themes as a user)
 dotconfigsub(){
-    if [ -d "~/.config/${1}" ]; then
-        echo "~/.config/${1}"
+    if [ -d ~/".config/${1}" ]; then
+        echo ~/".config/${1}"
     else
-        echo "@instantDotfiles@/${1}"
+        echo "@instantDotfiles@/share/instantdotfiles/${1}"
     fi
 }
 
@@ -23,9 +23,9 @@ checkdeprecated() {
 # better to use "real" getopt (and get rid of the Q&D pattern match below), 
 # but this would break non-standard "half-short" options (-wa -wi -wm) for now,
 # so these should be replaced everywhere where they are called
-for i in "$@"
-do
-case $i in
+
+# don't loop over options, they're mutually exclusive anyway
+case ${1} in
     --get-assist-dir|-a)
 	echo "@instantASSIST@"
     ;;
@@ -74,7 +74,8 @@ case $i in
     ;;
     *)
 		# unknown option
+        echo "Error: unknown option \"${1}\"" >&2
 		exit 1
     ;;
 esac
-done
+

--- a/instantdata.sh
+++ b/instantdata.sh
@@ -13,6 +13,11 @@ dotconfigsub(){
     fi
 }
 
+checkdeprecated() {
+    if [ -n "$(echo "${1}" | grep -E '\-[a-z]{2,}')" ]; then
+        echo "WARNING: deprecated option \"${1}\" will be removed in the future. Please use the long option \"${2}\"" >&2
+    fi
+}
 
 # ppenguin:
 # better to use "real" getopt (and get rid of the Q&D pattern match below), 
@@ -30,8 +35,8 @@ case $i in
     --get-dotfiles-dir|-d)
 	echo "@instantDotfiles@"
     ;;
-    --get-userconfig-dir=*|-uc=*)
-    optarg=$(echo $* | awk -F' ' '$1~/--get-userconfig-dir|-uc/ { match($1, /.*=(.*)/, a); print a[1] }' )
+    --get-userconfig-dir=*)
+    optarg=$(echo $* | awk -F' ' '$1~/--get-userconfig-dir/ { match($1, /.*=(.*)/, a); print a[1] }' )
 	dotconfigsub ${optarg}
     ;;
     --get-logo-dir|-l)
@@ -50,12 +55,15 @@ case $i in
 	echo "@instantUtils@"
     ;;
     --get-wallpaper-dir|-wa)
+    checkdeprecated ${1} "--get-wallpaper-dir"
 	echo "@instantWALLPAPER@"
     ;;
     --get-widgets-dir|-wi)
+    checkdeprecated ${1} "--get-widgets-dir"
 	echo "@instantWidgets@"
     ;;
     --get-wm-dir|-wm)
+    checkdeprecated ${1} "--get-wm-dir"
 	echo "@instantWM@"
     ;;
     --get-paperbash-dir|-p)


### PR DESCRIPTION
If `instant*` is installed system-wide, some programs using `instantdata` (e.g. `rofi`) will only evaluate the package-provided config files, and therefore not offer any possibility to override these as is usual in linux (e.g. `/usr/share/<package>/dfltconfigs` would be overridden with `~/.config/<package>/myconfigs`).

This mod adds an option to be used instead of `--get-dotfiles-dir` with an argument for the config dir under `~/.config/` to be used, with the original `--get-dotfiles-dir` return value + the chosen config dir as fallback.